### PR TITLE
Dirección en órdenes

### DIFF
--- a/nix/build.gradle
+++ b/nix/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	runtimeOnly 'mysql:mysql-connector-java'
 	compile group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
 	// H2 for development
-	#runtimeOnly 'com.h2database:h2'
+	//runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/nix/build.gradle
+++ b/nix/build.gradle
@@ -28,10 +28,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	// MySQL for production
-	runtimeOnly 'mysql:mysql-connector-java'
+	//runtimeOnly 'mysql:mysql-connector-java'
 	compile group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
 	// H2 for development
-	//runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/nix/build.gradle
+++ b/nix/build.gradle
@@ -28,10 +28,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	// MySQL for production
-	//runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'mysql:mysql-connector-java'
 	compile group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
 	// H2 for development
-	runtimeOnly 'com.h2database:h2'
+	#runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/nix/src/main/java/com/naat/nix/NixApplication.java
+++ b/nix/src/main/java/com/naat/nix/NixApplication.java
@@ -3,9 +3,15 @@ package com.naat.nix;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Clase main
+ */
 @SpringBootApplication
 public class NixApplication {
 
+	/**
+	 * Correr aplicación
+	 */
 	public static void main(String[] args) {
 		SpringApplication.run(NixApplication.class, args);
 	}

--- a/nix/src/main/java/com/naat/nix/menu/controller/CartController.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/CartController.java
@@ -14,7 +14,6 @@ import com.naat.nix.user.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,8 +22,8 @@ import org.springframework.web.servlet.ModelAndView;
 
 
 /**
-* Controlador encargado de la lectura, manipulacion de platillos del carrito
-*/
+ * Controlador encargado de la lectura, manipulacion de platillos del carrito
+ */
 @Controller
 @RequestMapping(value = "/cart")
 public class CartController {
@@ -46,13 +45,15 @@ public class CartController {
 
 
 	/**
-	* Solicitud para ver el carrito.
-	* Obtiene el carrito de la base de datos, lo referencia
-	* a la variable 'carrito' y carga sus platillos.
-	* en la vista VerCarritoIH.html.
-	**/
+	 * Solicitud para ver el carrito.
+	 * Obtiene el carrito de la base de datos, lo referencia
+	 * a la variable 'carrito' y carga sus platillos.
+	 * en la vista VerCarritoIH.html.
+	 * @param user Usuario activo
+	 * @return Vista con atributos
+	 */
 	@RequestMapping( value = "", method = RequestMethod.GET)
-	public ModelAndView verCarrito(@AuthenticationPrincipal UserWrapper user) {
+	public ModelAndView seeCart(@AuthenticationPrincipal UserWrapper user) {
 		User current = user.getCustomUser();
 		ModelAndView modelAndView = new ModelAndView("cart");
 		check(current);
@@ -63,11 +64,12 @@ public class CartController {
 
 
 	/**
-	* Solicitud para editar el carrito.
-	* Carga los platillos del carrito en la vista EliminarCarritoIH
-	*/
+	 * Solicitud para editar el carrito.
+	 * Carga los platillos del carrito en la vista EliminarCarritoIH
+	 * @return Vista con atributos
+	 */
 	@RequestMapping( value = "/edit", method = RequestMethod.GET)
-	public ModelAndView editarCarrito() {
+	public ModelAndView editCart() {
 		ModelAndView modelAndView = new ModelAndView("cart_delete");
 		ArrayList<Food> platillos = new ArrayList<Food>(carrito.getFoods());
 		modelAndView.addObject("carrito", platillos);
@@ -77,22 +79,24 @@ public class CartController {
 	}
 
 	/**
-	* Solicitud para descartar un platillo.
-	* Elimina el platillo del carrito.
-	* @param nombre el nombre del platillo a descartar
-	*/
+	 * Solicitud para descartar un platillo.
+	 * Elimina el platillo del carrito.
+	 * @param nombre El nombre del platillo a descartar
+	 * @return Nombre de plantilla a redireccionar
+	 */
 	@RequestMapping( value = "/edit/{name}")
-	public String descartar(@PathVariable("name") String nombre) {
+	public String discard(@PathVariable("name") String nombre) {
 		carrito.deleteByName(nombre);
 		return "redirect:/cart/edit";
 	}
 
 	/**
-	* Solicitud para eliminar los platillos descartados del carrito.
-	* Actualiza en la base de datos el carrito actual.
-	*/
+	 * Solicitud para eliminar los platillos descartados del carrito.
+	 * Actualiza en la base de datos el carrito actual.
+	 * @return Nombre de plantilla a redireccionar
+	 */
 	@RequestMapping( value = "/delete")
-	public String eliminar() {
+	public String delete() {
 		try {
 			cartService.update(carrito);
 		} catch ( Exception e) {
@@ -103,14 +107,16 @@ public class CartController {
 	}
 
 	/**
-	* Solicitud para agregar un platillo al carrito.
-	* Obten el platillo de la base de datos, guarda en el carrito
-	* y actualiza el carrito en la base de datos.
-	* Finalmente deririge a la vista del menu
-	* @param f el id del platillo a agregar
-	*/
+	 * Solicitud para agregar un platillo al carrito.
+	 * Obten el platillo de la base de datos, guarda en el carrito
+	 * y actualiza el carrito en la base de datos.
+	 * Finalmente deririge a la vista del menu
+	 * @param id El identificador del platillo a agregar
+	 * @param user Usuario actual
+	 * @return Nombre de plantilla a redireccionar
+	 */
 	@RequestMapping( value = "/add/{id}")
-	public String agregar(@PathVariable("id") int id,
+	public String add(@PathVariable("id") int id,
 	@AuthenticationPrincipal UserWrapper user) {
 		User current = user.getCustomUser();
 		Food p = foodService.getFoodById(id);
@@ -125,11 +131,12 @@ public class CartController {
 	}
 
 	/**
-	* Revisa si el carrito del usuario actual existe
-	* en la base de datos (porque puede que apenas se registro)
-	* y asigna a la variable carrito el valor
-	* de la base de datos
-	*/
+	 * Revisa si el carrito del usuario actual existe
+	 * en la base de datos (porque puede que apenas se registro)
+	 * y asigna a la variable carrito el valor
+	 * de la base de datos
+	 * @param user Usuario dueños de los carritos
+	 */
 	private void check (User user) {
 		// Revisa si el carrito se encuentra en la base de datos
 		carrito = cartService.getCartByEmail(user.getEmail());
@@ -143,32 +150,35 @@ public class CartController {
 		}
 	}
 
+	/**
+	 * Toma los contenidos del carrito actual y crea una orden con ellos
+	 * @param user Usuario actual
+	 */
 	@GetMapping(value = "/order")
-	public String confirmaOrden(Model model,
-	@AuthenticationPrincipal UserWrapper user) {
+	public String confirmOrder(@AuthenticationPrincipal UserWrapper user) {
 		
 		var platillos = carrito.getFoods();
 		var cliente = user.getCustomUser().getClient();
-		var precio = calculaPrecio();
+		var precio = totalPrice();
 		var orden = new Takeout();
 		orden.setFoodItems(platillos);
 		orden.setDeliveryDate(LocalDate.now());
 		orden.setPrice(precio);
 		orden.setClient(cliente);
-		//orden.setRepartidor(repartidor);
 		takeoutService.save(orden);
 		carrito = new Cart();
 		return "redirect:/menu";
 	}
 
-	
-	private double calculaPrecio() {
+	/**
+	 * Calcula el precio total de los contenidos del carrito actual
+	 * @return Precio total
+	 */
+	private double totalPrice() {
 			double total = 0;
 			for (Food f:carrito.getFoods()) {
 					total+=f.getPrice();
 			}
 			return total;
 	}
-	
-
 }

--- a/nix/src/main/java/com/naat/nix/menu/controller/CartController.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/CartController.java
@@ -1,13 +1,10 @@
 package com.naat.nix.menu.controller;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 
 import com.naat.nix.menu.model.Cart;
 import com.naat.nix.menu.model.CartID;
 import com.naat.nix.menu.model.Food;
-import com.naat.nix.order.controller.TakeoutService;
-import com.naat.nix.order.model.Takeout;
 import com.naat.nix.user.config.UserWrapper;
 import com.naat.nix.user.model.User;
 
@@ -37,8 +34,8 @@ public class CartController {
 	FoodService foodService;
 
 	/* Manejo de órdenes */
-	@Autowired
-	TakeoutService takeoutService;
+	//@Autowired
+	//TakeoutService takeoutService;
 
 	/* Referencia al carrito actual */
 	Cart carrito;
@@ -157,28 +154,8 @@ public class CartController {
 	@GetMapping(value = "/order")
 	public String confirmOrder(@AuthenticationPrincipal UserWrapper user) {
 		
-		var platillos = carrito.getFoods();
-		var cliente = user.getCustomUser().getClient();
-		var precio = totalPrice();
-		var orden = new Takeout();
-		orden.setFoodItems(platillos);
-		orden.setDeliveryDate(LocalDate.now());
-		orden.setPrice(precio);
-		orden.setClient(cliente);
-		takeoutService.save(orden);
+		cartService.order(carrito, user.getCustomUser().getClient());
 		carrito = new Cart();
 		return "redirect:/menu";
-	}
-
-	/**
-	 * Calcula el precio total de los contenidos del carrito actual
-	 * @return Precio total
-	 */
-	private double totalPrice() {
-			double total = 0;
-			for (Food f:carrito.getFoods()) {
-					total+=f.getPrice();
-			}
-			return total;
 	}
 }

--- a/nix/src/main/java/com/naat/nix/menu/controller/CartRepository.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/CartRepository.java
@@ -6,5 +6,8 @@ import org.springframework.stereotype.Repository;
 import com.naat.nix.menu.model.Cart;
 import com.naat.nix.menu.model.CartID;
 
+/**
+ * DAO de los carritos.
+ */
 @Repository
 public interface CartRepository extends CrudRepository<Cart, CartID>{}

--- a/nix/src/main/java/com/naat/nix/menu/controller/CartService.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/CartService.java
@@ -1,6 +1,7 @@
 package com.naat.nix.menu.controller;
 
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -10,6 +11,10 @@ import javax.persistence.Query;
 
 import com.naat.nix.menu.model.Cart;
 import com.naat.nix.menu.model.CartID;
+import com.naat.nix.menu.model.Food;
+import com.naat.nix.order.controller.TakeoutService;
+import com.naat.nix.order.model.Takeout;
+import com.naat.nix.user.model.Client;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,6 +32,10 @@ public class CartService {
   /* DAO para los carritos */
   @Autowired
   private CartRepository repository;
+
+  /* Manejo de órdenes */
+	@Autowired
+	TakeoutService takeoutService;
 
   /**
    * Obtiene todos los carritos existentes
@@ -104,5 +113,34 @@ public class CartService {
     }
     return a;
   }
+
+  /**
+   * Crea una orden con los contenidos de carrito
+   * @param c Carrito con los platillos
+   */
+  public void order(Cart c, Client client) {
+    var foods = c.getFoods();
+		var price = totalPrice(c);
+		var order = new Takeout();
+		order.setFoodItems(foods);
+		order.setDeliveryDate(LocalDate.now());
+		order.setPrice(price);
+    order.setClient(client);
+    // siempre elegir primera dirección
+		//order.setAddress(client.getAddress().get(0));
+		takeoutService.save(order);
+  }
+
+  /**
+	 * Calcula el precio total de los contenidos del carrito actual
+	 * @return Precio total
+	 */
+	private double totalPrice(Cart c) {
+    double total = 0;
+    for (Food f : c.getFoods()) {
+        total+=f.getPrice();
+    }
+    return total;
+}
 
 }

--- a/nix/src/main/java/com/naat/nix/menu/controller/CartService.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/CartService.java
@@ -14,22 +14,34 @@ import com.naat.nix.menu.model.CartID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+/**
+ * Manipulaciones de los carritos
+ */
 @Service
 public class CartService {
 
+  /* Manejador de entidades para crear consultas en SQL puro */
   @PersistenceContext
   EntityManager entityManager;
 
+  /* DAO para los carritos */
   @Autowired
   private CartRepository repository;
 
-  /* Obtiene todos los carritos */
+  /**
+   * Obtiene todos los carritos existentes
+   * @return Lista de todos los carritos
+   */
   public ArrayList<Cart> getCarts(){
     ArrayList<Cart> carritos = (ArrayList<Cart>) repository.findAll();
     return carritos;
   }
 
-  /* Obtiene el carrito por el id */
+  /**
+   * Obtiene el carrito por su identificador
+   * @param id Identificador del carritoc (como credencial embedida)
+   * @return Carrito con el identificador proporcionado
+   */
   public Cart getCartById(CartID id) {
     Optional<Cart> cart = repository.findById(id);
     if (cart.isPresent()) {
@@ -38,7 +50,11 @@ public class CartService {
     return null;
   }
 
-  /* Obtiene el carrito por el correo de usuario */
+  /**
+   * Obtiene el carrito por el corree del usuario
+   * @param correo_usuario Correo del usuario
+   * @return Carrito del usuario con el correo proporcionado
+   */
   public Cart getCartByEmail(String correo_usuario) {
     Query query = entityManager.createQuery("FROM Cart c WHERE c.cartId.email =: correo", Cart.class);
     query.setParameter("correo", correo_usuario);
@@ -50,18 +66,19 @@ public class CartService {
   }
 
   /**
-  * Guarda el carrito en la base de datos
-  * @param c el carrito a guardar
-  */
+   * Guarda el carrito en la base de datos
+   * @param c el carrito a guardar
+   * @return Carrito que se acaba de guardar
+   */
   public Cart save(Cart c) {
     Cart n = repository.save(c);
     return n;
   }
 
   /**
-  * Elimina el carrito si se encuentra en la base de datos
-  * @param c el carrito a elimnar
-  */
+   * Elimina el carrito si se encuentra en la base de datos
+   * @param c el carrito a elimnar
+   */
 
   public void delete(Cart c) {
     Optional<Cart> carrito = repository.findById(c.getCartId());
@@ -71,9 +88,11 @@ public class CartService {
   }
 
   /**
-  * Si el carrito se encuentra en la base de datos, lo actualiza
-  * @param c el carrito que se actualiza
-  */
+   * Si el carrito se encuentra en la base de datos, lo actualiza
+   * @param c El carrito que se actualiza
+   * @throws SQLIntegrityConstraintViolationException
+   * @return Carrito recien actualizado
+   */
   public Cart update(Cart c) throws SQLIntegrityConstraintViolationException {
     Optional<Cart> carrito = repository.findById(c.getCartId());
     Cart a = null;

--- a/nix/src/main/java/com/naat/nix/menu/controller/CategoryRepository.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/CategoryRepository.java
@@ -4,5 +4,8 @@ import com.naat.nix.menu.model.Category;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.repository.CrudRepository;
 
+/**
+ * DAO para las categorías de comida
+ */
 @Repository
 public interface CategoryRepository extends CrudRepository<Category, String>{}

--- a/nix/src/main/java/com/naat/nix/menu/controller/FoodRepository.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/FoodRepository.java
@@ -5,6 +5,8 @@ import com.naat.nix.menu.model.Food;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-
+/**
+ * DAO para los platillos
+ */
 @Repository
 public interface FoodRepository extends CrudRepository<Food, Integer>{}

--- a/nix/src/main/java/com/naat/nix/menu/controller/FoodService.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/FoodService.java
@@ -8,20 +8,30 @@ import com.naat.nix.menu.model.Food;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-
+/**
+ * Manipulación de los platillos
+ */
 @Service
 public class FoodService {
 
+  /* DAO para manipular platillos en la base de datos */
   @Autowired
   private FoodRepository repository;
 
-  /* Obtiene todos los platillos */
+  /**
+   * Obtiene todos los platillos disponibles
+   * @return Lista de todos los platillos del menú
+   */
   public ArrayList<Food> getFoods() {
     ArrayList<Food> platillos = (ArrayList<Food>) repository.findAll();
     return platillos;
   }
 
-  /* Obtiene el platillo con el id */
+  /**
+   * Platillo con el identificador dado
+   * @param id Identificador del platillo buscado
+   * @return Platillo con el identificador dado
+   */
   public Food getFoodById(int id) {
     Optional<Food> platillo = repository.findById(id);
     if (platillo.isPresent()) {
@@ -32,9 +42,10 @@ public class FoodService {
 
 
   /**
-  * Guarda el platillo en la base de datos
-  * @param p el platillo que se va a crear
-  */
+   * Guarda el platillo en la base de datos
+   * @param p Platillo que se va a crear
+   * @return Platillo recién creado
+   */
   public Food save(Food p) {
     Food n = repository.save(p);
     return n;
@@ -42,9 +53,9 @@ public class FoodService {
 
 
   /**
-  * Elimina el platillo si se encuentra en la base de datos
-  * @param p el platillo a eliminar
-  */
+   * Elimina el platillo si se encuentra en la base de datos
+   * @param p el platillo a eliminar
+   */
   public void delete(Food p) {
     Optional<Food> platillo = repository.findById(p.getIdFood());
     if (platillo.isPresent()) {
@@ -53,9 +64,10 @@ public class FoodService {
   }
 
   /**
-  * Si el platillo se encuentra en la base de datos, lo actualiza
-  * @param p el platillo que se actualiza
-  */
+   * Si el platillo se encuentra en la base de datos, lo actualiza
+   * @param p Platillo a actualizar
+   * @return Platillo recién actualizado
+   */
   public Food update(Food p) {
     Optional<Food> platillo = repository.findById(p.getIdFood());
     Food s = null;

--- a/nix/src/main/java/com/naat/nix/menu/controller/MenuController.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/MenuController.java
@@ -6,12 +6,15 @@ import com.naat.nix.menu.model.Food;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
-
+/**
+ * Manipulación del menú
+ */
 @Controller
+@RequestMapping(value = "/menu")
 public class MenuController {
 
   /* El servicio para manejar las operaciones sobre los platillos */
@@ -19,10 +22,11 @@ public class MenuController {
   FoodService foodService;
 
   /**
-  * Solicitud para ver todos los platillos del menu
-  **/
-  @RequestMapping( value = "/menu", method = RequestMethod.GET )
-  public ModelAndView verCarrito() {
+   * Solicitud para ver el menu
+   * @return Vista y atributos del menú
+   **/
+  @GetMapping
+  public ModelAndView getMenu() {
     ModelAndView modelAndView = new ModelAndView("menu");
     ArrayList<Food> platillos = new ArrayList<Food>(foodService.getFoods());
     modelAndView.addObject("menu", platillos);

--- a/nix/src/main/java/com/naat/nix/menu/controller/MenuInitialization.java
+++ b/nix/src/main/java/com/naat/nix/menu/controller/MenuInitialization.java
@@ -10,15 +10,23 @@ import com.naat.nix.menu.model.Food;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * Menú demo
+ */
 @Component
 public class MenuInitialization {
 
+  /* DAO para manejar categorias */
   @Autowired
   private CategoryRepository categoryDao;
 
+  /* DAO para manejar platillos */
   @Autowired
   private FoodRepository foodDao;
 
+  /**
+   * Creando entradas de un menú demo
+   */
   @PostConstruct
   public void addMenu() {
     // Algunas categorías

--- a/nix/src/main/java/com/naat/nix/menu/model/Cart.java
+++ b/nix/src/main/java/com/naat/nix/menu/model/Cart.java
@@ -12,6 +12,9 @@ import javax.persistence.Table;
 
 import lombok.Data;
 
+/**
+ * Representación del carrito en la base de datos
+ */
 @Data
 @Entity
 @Table(name="Carrito")

--- a/nix/src/main/java/com/naat/nix/menu/model/CartID.java
+++ b/nix/src/main/java/com/naat/nix/menu/model/CartID.java
@@ -6,7 +6,9 @@ import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import lombok.Data;
 
-/* Representa la llave primaria compuesta del objeto Cart */
+/**
+ * Representa la llave primaria compuesta del objeto carrito
+ */
 @Data
 @Embeddable
 public class CartID implements Serializable {

--- a/nix/src/main/java/com/naat/nix/menu/model/Category.java
+++ b/nix/src/main/java/com/naat/nix/menu/model/Category.java
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Representación de una categoría de comida en la base de datos
+ */
 @Data
 @NoArgsConstructor
 @RequiredArgsConstructor

--- a/nix/src/main/java/com/naat/nix/menu/model/Food.java
+++ b/nix/src/main/java/com/naat/nix/menu/model/Food.java
@@ -15,6 +15,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Representación de un platillo en la base de datos
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/nix/src/main/java/com/naat/nix/order/controller/TakeoutController.java
+++ b/nix/src/main/java/com/naat/nix/order/controller/TakeoutController.java
@@ -10,12 +10,22 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+/**
+ * Controla las URL para manejar órdenes
+ */
 @Controller
 @RequestMapping(value = "/orders")
 public class TakeoutController {
+  /* Servicio donde se obtiene todo lo necesario para realizar las peticiones */
   @Autowired
   private TakeoutService service;
 
+  /**
+   * Añade todas las órdenes pertinentes a la vista
+   * @param model Modelo actual
+   * @param principal Usuario actual
+   * @return Nombre de la plantilla de la vista
+   */
   @GetMapping
   public String getOrders(Model model, @AuthenticationPrincipal UserWrapper principal) {
     var orders = service.getOrders(principal);
@@ -23,6 +33,12 @@ public class TakeoutController {
     return "orders";
   }
 
+  /**
+   * Añade a la vista las órdenes que un repartidor puede seleccionar
+   * @param model Modelo actual
+   * @param principal Usuario actual (un repartidor)
+   * @return Nombre de la plantilla de la vista
+   */
   @GetMapping("/select/{takeoutId}")
   public String selectOrder(Model model, @PathVariable Long takeoutId,
       @AuthenticationPrincipal UserWrapper principal) throws Exception {
@@ -31,6 +47,12 @@ public class TakeoutController {
     return "redirect:/orders";
   }
 
+  /**
+   * Añade a la vista las órdenes cuyo estatus se puede actualizar
+   * @param model Modelo actual
+   * @param principal Usuario actual (repartidor o administrador)
+   * @return Nombre de la plantilla de la vista
+   */
   @GetMapping("update/{takeoutId}")
   public String updateOrder(Model model, @PathVariable Long takeoutId,
     @AuthenticationPrincipal UserWrapper principal) throws Exception {

--- a/nix/src/main/java/com/naat/nix/order/controller/TakeoutRepository.java
+++ b/nix/src/main/java/com/naat/nix/order/controller/TakeoutRepository.java
@@ -7,16 +7,11 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 /**
- * Managing Takeout entity manipulation with the DB.
+ * DAO de las órdenes
  */
 @Repository
 public interface TakeoutRepository extends CrudRepository<Takeout, Long>{
 
-  /**
-   * Filtering orders by client
-   * @param id
-   * @return Iterable of all the client takeout orders.
-   */
   Iterable<Takeout> findByClientEmail(String email);
 
   Iterable<Takeout> findByDeliveryManEmail(String emal);

--- a/nix/src/main/java/com/naat/nix/order/model/DeliveryStatus.java
+++ b/nix/src/main/java/com/naat/nix/order/model/DeliveryStatus.java
@@ -1,29 +1,17 @@
 package com.naat.nix.order.model;
 
 /**
- * Enumeration representing the status of a takeout order.
+ * Posibles estatus de una orden
  * @version 1.0
  */
 public enum DeliveryStatus {
-  /**
-   * Still preparing the order.
-   */
-  PREPARING,
-  /**
-   * Order ready to be taken.
-   */
-  READY,
-  
-  /**
-   * Order in the way.
-   */
-  DELIVERING,
-  
-  /**
-   * Order already delivered.
-   */
-  DELIVERED;
 
+  PREPARING, READY, DELIVERING, DELIVERED;
+
+  /**
+   * Descripción en español de los estatus
+   * @return Cade que describe el estatus
+   */
   public String toString() {
     var s = "";
     switch(this) {

--- a/nix/src/main/java/com/naat/nix/order/model/Takeout.java
+++ b/nix/src/main/java/com/naat/nix/order/model/Takeout.java
@@ -45,6 +45,9 @@ public class Takeout {
   @Column(name="precio")
   private Double price;
 
+  @Column(name="domicilio")
+  private String address;
+
   @ManyToMany
   @JoinTable(
     name="takeout_contains_food",

--- a/nix/src/main/java/com/naat/nix/order/model/Takeout.java
+++ b/nix/src/main/java/com/naat/nix/order/model/Takeout.java
@@ -22,44 +22,29 @@ import com.naat.nix.user.model.DeliveryMan;
 import lombok.Data;
 
 /**
- * Class representing a takeout food order.
- * @version 1.0
+ * Representación de una órden de comida para la base de datos
  */
 @Data
 @Entity
 @Table(name="Orden")
 public class Takeout {
-  /**
-   * Generated key column.
-   */
+
   @GeneratedValue
   @Id
   private Long id;
 
-  /**
-   * Order's date. Assuming a order is fullfillied in one day.
-   */
   @Column(
     columnDefinition="TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
     name="entrega"
   )
   private LocalDate deliveryDate;
 
-  /**
-   * Order status.
-   */
   @Enumerated(EnumType.STRING)
   private DeliveryStatus status = DeliveryStatus.PREPARING;
 
-  /**
-   * Precio total de los alimentos
-   */
   @Column(name="precio")
   private Double price;
 
-  /**
-   * Food in the order.
-   */
   @ManyToMany
   @JoinTable(
     name="takeout_contains_food",
@@ -69,16 +54,10 @@ public class Takeout {
   @Column(name="platillos")
   private List<Food> foodItems;
 
-  /**
-   * Person who bought the order.
-   */
   @ManyToOne
   @JoinColumn(name="cliente")
   private Client client;
 
-  /**
-   * Person in charge of the deliverying.
-   */
   @ManyToOne
   @JoinColumn(name="repartidor")
   private DeliveryMan deliveryMan;

--- a/nix/src/main/java/com/naat/nix/user/config/SecurityConfiguration.java
+++ b/nix/src/main/java/com/naat/nix/user/config/SecurityConfiguration.java
@@ -17,15 +17,24 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+/**
+ * Configuraciones no por omisión de la seguridad de Spring
+ */
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled  = true)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter{
 
+  /* Manejar conversión entre usuarios de Spring y usuarios de la aplicación */
   @Autowired
   private UserDetailsService userConfiguration;
 
 
+  /**
+   * Desabilitar indentificación para la consola de la base de datos de prueba.
+   * Tiene su propio sistema de usuarios que conflictua con el de Spring.
+   * @param web Configuración web
+   */
   @Override
   public void configure(WebSecurity web) throws Exception {
     web
@@ -33,6 +42,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter{
       .antMatchers("/h2-console/**");
   }
   
+  /**
+   * Forzar identificació para todas las URL excepto para el login, sign up y logout.
+   * En caso de login, forzar ingreso de credenciales.
+   * @param http Configuración HTTP
+   */
   @Override
   public void configure(HttpSecurity http) throws Exception {
     http
@@ -52,6 +66,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter{
         .logoutSuccessUrl("/login?logout");
   }
 
+  /**
+   * Registrar nuestro servicio para manejar usuarios y un encriptador para constraseñas
+   * @return Proveedor de credenciales usando base de datos.
+   */
   @Bean
   public AuthenticationProvider daoAuthenticationProvider() {
     var provider = new DaoAuthenticationProvider();
@@ -60,17 +78,29 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter{
     return provider;
   }
 
+  /**
+   * Seleccionar un cifrado de BCrypt como el que se va a usar
+   * @return Encriptador a usar
+   */
   @Bean
   public PasswordEncoder encoder() {
     return new BCryptPasswordEncoder();
   }
 
+  /**
+   * Selecciona manejador de credenciales
+   * @return Manejador de credenciales
+   */
   @Bean
   public AuthenticationManager customAuthenticationManager() throws Exception {
     return authenticationManager();
   }
 
 
+  /**
+   * Registrar nuestro servicio para manejar usuarios y un encriptador para constraseñas
+   * @param auth Registro para configuraciones de autentificación
+   */
   @Autowired
   public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
     auth.userDetailsService(userConfiguration).passwordEncoder(encoder());

--- a/nix/src/main/java/com/naat/nix/user/config/UserConfiguration.java
+++ b/nix/src/main/java/com/naat/nix/user/config/UserConfiguration.java
@@ -13,15 +13,20 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 /**
- * Service implementation to use custom users with the default Spring Security
- * configuration.
+ * Construir usuario de Spring con un usuario de la aplicación (en la base de datos)
  */
 @Service
 public class UserConfiguration implements UserDetailsService{
 
+  /* DAO para manejar usuarios*/
   @Autowired
   private UserRepository dao;
 
+  /**
+   * Obtener un usuario de Spring usando usando un email
+   * @param email Identificador del usuario de Spring
+   * @return Usuario de Spring
+   */
   public UserDetails loadUserByUsername(String email) {
     User user = dao.findByEmail(email);
     if (user == null) {
@@ -30,6 +35,11 @@ public class UserConfiguration implements UserDetailsService{
     return buildUser(user);
   }
 
+  /**
+   * Crear instancia de usuario de Spring usando un usuario de la aplicación
+   * @param user Usuario de la aplicación
+   * @return Usuario de Spring
+   */
   private UserWrapper buildUser(User user) {
     String username = user.getEmail();
     String password = user.getPassword();

--- a/nix/src/main/java/com/naat/nix/user/config/UserInitialization.java
+++ b/nix/src/main/java/com/naat/nix/user/config/UserInitialization.java
@@ -12,18 +12,33 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+/**
+ * Usuarios iniciales para demo del sistema
+ */
 @Component
 public class UserInitialization {
 
+  /**
+   * Encriptador para constraseñas
+   */
   @Autowired
   private PasswordEncoder encoder;
 
+  /**
+   * DAO para administradores
+   */
   @Autowired
   private AdminRepository adminDao;
 
+  /**
+   * Manipulación de usuarios
+   */
   @Autowired
   private UserService userService;
 
+  /**
+   * Creando varios usuarios iniciales de todo tipo
+   */
   @PostConstruct
   public void addUsers() {
 

--- a/nix/src/main/java/com/naat/nix/user/config/UserWrapper.java
+++ b/nix/src/main/java/com/naat/nix/user/config/UserWrapper.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 
+/**
+ * Implementación de usuario de Spring que envuelva a usuarios de la aplicación
+ */
 public class UserWrapper extends User {
   private static final long serialVersionUID = 1L;
 

--- a/nix/src/main/java/com/naat/nix/user/controller/AdminRepository.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/AdminRepository.java
@@ -4,6 +4,9 @@ import com.naat.nix.user.model.Admin;
 
 import org.springframework.data.repository.CrudRepository;
 
+/**
+ * DAO para administradores
+ */
 public interface AdminRepository extends CrudRepository<Admin, String>{
 
 }

--- a/nix/src/main/java/com/naat/nix/user/controller/ClientRepository.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/ClientRepository.java
@@ -4,6 +4,9 @@ import com.naat.nix.user.model.Client;
 
 import org.springframework.data.repository.CrudRepository;
 
+/**
+ * DAO para clientes
+ */
 public interface ClientRepository extends CrudRepository<Client, String>{
   public Client findByEmail(String email);
 }

--- a/nix/src/main/java/com/naat/nix/user/controller/ClientService.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/ClientService.java
@@ -5,16 +5,31 @@ import com.naat.nix.user.model.Client;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+/**
+ * Manipulaciómn de clientes
+ */
 @Service
 public class ClientService {
 
+    /**
+     * DAO de clientes
+     */
     @Autowired
     private ClientRepository clientRepository;
 
+    /**
+     * Obtener un cliente usando su correo
+     * @param email Correo del cliente
+     * @return Cliente con el correo dado
+     */
     public Client findByEmail (String email){
       return clientRepository.findByEmail(email);
     }
 
+    /**
+     * Guarda un cliente en la base de datos
+     * @param client Cliente a modificar
+     */
     public void saveClient (Client client) {
       clientRepository.save(client);
     }

--- a/nix/src/main/java/com/naat/nix/user/controller/DeliveryManRepository.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/DeliveryManRepository.java
@@ -4,6 +4,9 @@ import com.naat.nix.user.model.DeliveryMan;
 
 import org.springframework.data.repository.CrudRepository;
 
+/**
+ * DAO para repartidores
+ */
 public interface DeliveryManRepository extends CrudRepository<DeliveryMan, String>{
 
 }

--- a/nix/src/main/java/com/naat/nix/user/controller/LogInController.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/LogInController.java
@@ -7,9 +7,19 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+/**
+ * Manejando URL de login
+ */
 @Controller
 public class LogInController {
 
+    /**
+     * Agregar elementos a la vista de login
+     * @param model Modelo de la vista actual
+     * @param error Mensaje al ser redirigido al no ingresar las credenciales adecuadas
+     * @param logout Mensaje al hacer logout
+     * @return Nombre de la vista que se mostrará
+     */
     @GetMapping("/login")
     public String login(Model model, String error, String logout) {
         if (error != null){
@@ -21,6 +31,12 @@ public class LogInController {
         return "login";
     }
 
+    /**
+     * Redireccionar a la página de inicio dependiendo del tipo de usuario
+     * @param model Modelo de la vista actual
+     * @param user Usuario actual
+     * @return Nombre de la vista que se mostrará
+     */
     @GetMapping("/")
     public String index(Model model, @AuthenticationPrincipal UserWrapper user) {
         String email = user.getCustomUser().getEmail();

--- a/nix/src/main/java/com/naat/nix/user/controller/SecurityService.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/SecurityService.java
@@ -10,18 +10,28 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
+/**
+ * Configuraciones no por omisión para la seguridad de los usuarios
+ */
 @Service
 public class SecurityService {
 
+    /* Manejar credenciales */
     @Autowired
     private AuthenticationManager authenticationManager;
 
+    /* Obtener ususario de Spring desde usuarios de la aplicación */
     @Autowired
     private UserDetailsService userDetailsService;
 
+    /* Logger */
     final Logger logger = LoggerFactory.getLogger(SecurityService.class);
 
 
+    /**
+     * Obtener usuario actual
+     * @return correo del usuario actual
+     */
     public String findLoggedInUsername() {
         Object userDetails = SecurityContextHolder.getContext().getAuthentication().getDetails();
         if (userDetails instanceof UserDetails) {
@@ -32,6 +42,11 @@ public class SecurityService {
     }
 
 
+    /**
+     * Autentificar el usuario con las credenciales dadas
+     * @param username Correo
+     * @param password Contraseña
+     */
     public void autoLogin(String username, String password) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, password, userDetails.getAuthorities());

--- a/nix/src/main/java/com/naat/nix/user/controller/SigUpController.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/SigUpController.java
@@ -15,24 +15,48 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
+/**
+ * Manejo de URL para el rigistro de usuarios
+ */
 @Controller
 public class SigUpController {
 
+      /**
+       * Manipulación de usuarios
+       */
       @Autowired
       private UserService userService;
 
+      /**
+       * Revisión de potenciales usuarios
+       */
       @Autowired
       private SecurityService securityService;
 
+      /**
+       * Validar información de usuarios
+       */
       @Autowired
       private UserValidator userValidator;
 
+      /**
+       * Crear formulario vacío para clientes
+       * @param modelo Modelo actual de la vista
+       * @return Nombre de la vista a mostrar
+       */
       @GetMapping("/signup")
       public String registration(Model model) {
           model.addAttribute("clientForm", new ClientForm());
           return "signup";
       }
 
+      /**
+       * Procesar formulario de clientes
+       * Intenta crear nuevo cliente con la información.
+       * @param clientForm Datos del formulario
+       * @param bindingResult Resultados de la validación del formulario
+       * @return Nombre de la vista a mostrar
+       */
       @PostMapping("/signup")
       public String registration(@ModelAttribute @Valid ClientForm clientForm, BindingResult bindingResult) {
           User user = new User();
@@ -55,6 +79,11 @@ public class SigUpController {
           return "redirect:/";
       }
 
+      /**
+       * Crear formulario vacío para registrar repartidores
+       * @param modelo Modelo actual de la vista
+       * @return Nombre de la vista a mostrar
+       */
       @GetMapping("/signup/delivery")
       @Secured("ROLE_ADMIN")
       public String deliveryRegistration(Model model) {
@@ -62,6 +91,13 @@ public class SigUpController {
         return "delivery_signup";
       }
 
+      /**
+       * Procesar formulario de repartidores
+       * Intenta crear nuevo repartidor con la información.
+       * @param user Usuario con datos del formulario
+       * @param bindingResult Resultados de la validación del formulario
+       * @return Nombre de la vista a mostrar
+       */
       @PostMapping("signup/delivery")
       @Secured("ROLE_ADMIN")
       public String deliveryRegistration(@ModelAttribute @Valid User user, BindingResult result) {

--- a/nix/src/main/java/com/naat/nix/user/controller/UserRepository.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/UserRepository.java
@@ -4,6 +4,9 @@ import com.naat.nix.user.model.User;
 
 import org.springframework.data.repository.CrudRepository;
 
+/**
+ * DAO para usuarios
+ */
 public interface UserRepository extends CrudRepository<User, String>{
     User findByEmail (String email);
     User findByUsername (String name);

--- a/nix/src/main/java/com/naat/nix/user/controller/UserService.java
+++ b/nix/src/main/java/com/naat/nix/user/controller/UserService.java
@@ -11,30 +11,54 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+/**
+ * Manipulacion de usuarios
+ */
 @Service
 public class UserService {
 
+    /* DAO para usuarios */
     @Autowired
     private UserRepository userRepository;
 
+    /* DAO para repartidores */
     @Autowired
     private DeliveryManRepository deliveryRepository;
 
+    /* DAO para clientes */
     @Autowired
     private ClientRepository clientRepository;
 
+    /* Encriptador para contraseñas */
     @Autowired
     private BCryptPasswordEncoder bCryptPasswordEncoder;
 
 
+    /**
+     * Obtener un usuario usando su correo
+     * @param email Correo del usuario
+     * @return Usuario con el correo dado
+     */
     public User findByEmail (String email){
       return userRepository.findByEmail(email);
     }
 
+    /**
+     * Obtener un usuario usando su nombre de usuario
+     * @param name nombre de usuario
+     * @return Usuario con el nombre dado
+     */
     public User findByUsername (String name) {
       return userRepository.findByUsername(name);
     }
 
+    /**
+     * Crear y guarda un cliente nuevo usando un usuario y la informaciń de un
+     * formulario de registro de cliente
+     * @param user Usuario
+     * @param clientForm Formulario de registro de cliente
+     * @return Cliente nuevo
+     */
     public Client newClient (User user, ClientForm clientForm) {
       Client client = new Client();
       client.setEmail(user.getEmail());
@@ -46,6 +70,11 @@ public class UserService {
       return client;
     }
 
+    /**
+     * Crea y guarda un repartidor nuevo usando un usuario
+     * @param user Usuario
+     * @return Repartidor nuevo
+     */
     public DeliveryMan newDelivery(User user) {
       DeliveryMan deliveryMan = new DeliveryMan();
       deliveryMan.setEmail(user.getEmail());
@@ -55,6 +84,10 @@ public class UserService {
       return deliveryMan;
     }
 
+    /**
+     * Guarda las modificacione a un usuario en la base de datos
+     * @param user Usuario
+     */
     public void saveUser (User user){
       user.setPassword (bCryptPasswordEncoder.encode(user.getPassword()));
       userRepository.save(user);

--- a/nix/src/main/java/com/naat/nix/user/model/Admin.java
+++ b/nix/src/main/java/com/naat/nix/user/model/Admin.java
@@ -15,6 +15,9 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Representación de administrador en la base de datos
+ */
 @Data
 @NoArgsConstructor
 @RequiredArgsConstructor

--- a/nix/src/main/java/com/naat/nix/user/model/Client.java
+++ b/nix/src/main/java/com/naat/nix/user/model/Client.java
@@ -22,6 +22,9 @@ import org.hibernate.annotations.NotFoundAction;
 
 import lombok.Data;
 
+/**
+ * Representación de clientes en la base de datos
+ */
 @Data
 @Entity
 @Table(name = "Cliente")

--- a/nix/src/main/java/com/naat/nix/user/model/ClientForm.java
+++ b/nix/src/main/java/com/naat/nix/user/model/ClientForm.java
@@ -3,7 +3,7 @@ package com.naat.nix.user.model;
 import lombok.Data;
 
 /**
- * Form for client signup
+ * Guardar información de formulario de registro de cliente
  */
 @Data
 public class ClientForm {

--- a/nix/src/main/java/com/naat/nix/user/model/DeliveryMan.java
+++ b/nix/src/main/java/com/naat/nix/user/model/DeliveryMan.java
@@ -19,6 +19,9 @@ import org.hibernate.annotations.NotFoundAction;
 
 import lombok.Data;
 
+/**
+ * Representación de repartidores en la base de datos
+ */
 @Data
 @Entity
 @Table(name = "Repartidor")

--- a/nix/src/main/java/com/naat/nix/user/model/User.java
+++ b/nix/src/main/java/com/naat/nix/user/model/User.java
@@ -15,8 +15,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Entity representing users of our system. Extends UserDetails to use with
- * Spring Security.
+ * Representación de usuarios en la base de datos.
  */
 @Data
 @Entity

--- a/nix/src/main/java/com/naat/nix/validator/UserValidator.java
+++ b/nix/src/main/java/com/naat/nix/validator/UserValidator.java
@@ -8,17 +8,27 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+/**
+ * Validar formulario de registro
+ */
 @Component
 public class UserValidator implements Validator {
 
+    /* Manipulación de usuarios */
     @Autowired
     private UserService userService;
 
+    /**
+     * Revisar si la clase dada es la de usuario
+     */
     @Override
     public boolean supports(Class<?> aClass) {
         return User.class.equals(aClass);
     }
 
+    /**
+     * Revisa si el objeto dado es un usuario no registrado
+     */
     @Override
     public void validate (Object o, Errors errors) {
         User user = (User) o;

--- a/nix/src/main/resources/application.properties
+++ b/nix/src/main/resources/application.properties
@@ -2,10 +2,10 @@
 spring.thymeleaf.prefix=classpath:/templates/
 
 # configuración de la base de datos
-#spring.datasource.url=${SPRING_DATASOURCE_URL}
-#spring.datasource.username=${SPRING_USERNAME}
-#spring.datasource.password=${SPRING_PASS}
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-#spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_USERNAME}
+spring.datasource.password=${SPRING_PASS}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
 
 spring.messages.basename=validation

--- a/nix/src/main/resources/application.properties
+++ b/nix/src/main/resources/application.properties
@@ -2,10 +2,10 @@
 spring.thymeleaf.prefix=classpath:/templates/
 
 # configuración de la base de datos
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_USERNAME}
-spring.datasource.password=${SPRING_PASS}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=create-drop
+#spring.datasource.url=${SPRING_DATASOURCE_URL}
+#spring.datasource.username=${SPRING_USERNAME}
+#spring.datasource.password=${SPRING_PASS}
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.jpa.hibernate.ddl-auto=create-drop
 
 spring.messages.basename=validation

--- a/nix/src/main/resources/templates/fragments/common.html
+++ b/nix/src/main/resources/templates/fragments/common.html
@@ -105,6 +105,7 @@
   <div class="card-body" th:fragment="ordercard_body">
     <h5 class="card-title" th:text="${order.status}"></h5>
     <p class="card-text" th:text="'Fecha de entrega: ' + ${order.deliveryDate}"></p>
+    <p class="card-text" th:text="'Domicilio de entrega: ' + ${order.client.address.get(0)}"></p>
     <p class="card-text" th:text="'Total: $' + ${order.price}"></p>
     <p>Platillos: </p>
     <ul>


### PR DESCRIPTION
Se agrega una dirección en las órdenes y se muestra en el panel de órdenes

Para asignar la dirección intenté usar las direcciones del cliente, pero hubo un error en la sesión de Hibernate. Al parecer, no se cargan los atributos que no sean datos primitivos si no se está en el DAO.

Así que como solución paleativa, la dirección de la orden se queda en blanco, y desde la vista se accede al usuario de la orden, y se muetra su primera dirección.

No es ideal, pero es suficiente.